### PR TITLE
Remove `of_file` function from exercises

### DIFF
--- a/ofronds_internals/exercise.ml
+++ b/ofronds_internals/exercise.ml
@@ -83,9 +83,3 @@ module Set = struct
           (Fmt.str "! Failed to compile `%a'. Here's the output:" pp_path ex)
           User_message.with_surrounding_box lines
 end
-
-let of_file path ~name =
-  let* { by_name; _ } = Set.of_file path in
-  match Hashtbl.find_opt by_name name with
-  | Some x -> Ok x
-  | None -> Error `Name_absent

--- a/ofronds_internals/exercise.mli
+++ b/ofronds_internals/exercise.mli
@@ -7,11 +7,6 @@ val name : t -> string
 val pp_path : t Fmt.t
 (** Pretty-prints the file path associated with the exercise. *)
 
-val of_file :
-  string -> name:string -> (t, [ `File_not_found | `Name_absent ]) result
-(** [of_file path ~name] loads the exercise named [name] from the given metadata
-    file [path]. *)
-
 val compile : t -> (unit, [ `Output of string list ]) result
 (** [compile ex] attempts to build exercise [ex] with Dune. If the build fails,
     the compiler output is returned. *)


### PR DESCRIPTION
We would always want to lazy load the exercises since it's a heavy computation
so removing this function in case we use it accidentally.

Co-authored-by: Sonja Heinze <sonjaleaheinze@gmail.com>